### PR TITLE
Check if both width and height match during trimming

### DIFF
--- a/src/image_wrapper.rs
+++ b/src/image_wrapper.rs
@@ -75,7 +75,7 @@ impl ImageWrapper {
         let frame_w = w;
         let frame_h = h;
 
-        let (frame_x, frame_y, data) = if width == w {
+        let (frame_x, frame_y, data) = if width == w && height == h {
             (0, 0, pixels)
         } else {
             // create the trimmed image data


### PR DESCRIPTION
Fixes #8 

Would only check if width matched non-transparent width before, so transparent top pixels wouldn't trigger the trimming logic & would output the transparent pixels trimmed to the appropriate size.